### PR TITLE
Replace non-existing word with a fitting one.

### DIFF
--- a/threshold-signature-scheme/emergency-recovery.md
+++ b/threshold-signature-scheme/emergency-recovery.md
@@ -6,7 +6,7 @@ description: What happens if the TSS software is unavailable
 
 ## What is the Emergency Recovery Tool?
 
-In Vultisig the private key never exists, improving the security by timesfold since there is no private key to be extracted or stolen. 
+In Vultisig the private key never exists, improving the security manyfold since there is no private key to be extracted or stolen. 
 
 It is possible though to recombine the vault shares of a vault and generate the private key to extract it and use it in other wallets. Scripts are created to allow users to do this if the Vultisig app ever goes offline:
 


### PR DESCRIPTION
In the docs there is this sentence in the "Emergency Recovery" section:
> In Vultisig the private key never exists, improving the security by timesfold since there is no private key to be extracted or stolen.

The phrase "**by timesfold**" sounds odd because "**timesfold**" isn't really a word.
I think what was meant is "**manyfold**", as in `improving the security by many times`.
Thus the adjusted sentence would be: `improving the security manyfold`