### PR TITLE
Minor QA fixes

### DIFF
--- a/FAQ/README.md
+++ b/FAQ/README.md
@@ -108,7 +108,7 @@ _Scenario 2 :_ WITHOUT mobile remote data wipe feature setup done and with at le
 2. Immediately move your funds away from this existing vault.
 
 {% hint style="warning" %}
-**You would still loss access to your funds if you do not have at least 67% of vault shares backup done properly.**\
+**You would still lose access to your funds if you do not have at least 67% of vault shares backup done properly.**\
 **ALWAYS BACK UP EACH DEVICE INDIVIDUALLY**
 {% endhint %}
 

--- a/vultisig-ecosystem/vulticonnect/how-to-use-vultisig-connect.md
+++ b/vultisig-ecosystem/vulticonnect/how-to-use-vultisig-connect.md
@@ -8,4 +8,4 @@ Install Vultisig Extension for your Chrome Browser, over the Chrome Extension St
 
 ## How to use Vultisig Extension
 
-The extension can be used in the same way as the mobile and desktop apps, and all actions can be read in the[ user actions](broken-reference).
+The extension can be used in the same way as the mobile and desktop apps, and all actions can be read in the [user actions](../../vultisig-vault-user-actions/creating-a-vault.md).

--- a/vultisig-token/airdrop/README.md
+++ b/vultisig-token/airdrop/README.md
@@ -73,7 +73,7 @@ The Ongoing Airdrop Process will continue for another 5 years, and the dedicated
 1.  [Export](../../vultisig-vault-user-actions/managing-your-vault/vault-qr.md) the Vault QR of the Vultisig Vault\\
 
     <figure><img src="../../.gitbook/assets/VultisigQR-Main Vault-828 (1).png" alt="" width="188"><figcaption></figcaption></figure>
-2.  Connect to the [airdrop](https://airdrop.vultisig.com/import) page with your [Vultisig Connect](../../vult-token/broken-reference/) or with uploading your Vault QR\\
+2.  Connect to the [airdrop](https://airdrop.vultisig.com/import) page with your [Vultisig Extension](../../vultisig-ecosystem/vulticonnect/README.md) or by uploading your Vault QR\\
 
     <figure><img src="../../.gitbook/assets/image (11).png" alt="" width="375"><figcaption></figcaption></figure>
 3.  Join the Airdrop with your connected Vault with clicking `Join Airdrop` on the website\\

--- a/vultisig-vault-user-actions/managing-your-vault/vault-backup.md
+++ b/vultisig-vault-user-actions/managing-your-vault/vault-backup.md
@@ -13,7 +13,7 @@ These shares store all the data necessary to participate in Keygen/Keysign sessi
 **They never store any secret key or seed phrase.**
 
 {% hint style="info" %}
-The parameters stored in Vault Shares are non-sensitive data and are unique to the device on which they are created, making Vault Shares unique and not interchangeable with eachother.
+The parameters stored in Vault Shares are non-sensitive data and are unique to the device on which they are created, making Vault Shares unique and not interchangeable with each other.
 {% endhint %}
 
 <figure><img src="../../.gitbook/assets/image (1) (1) (1).png" alt=""><figcaption><p>Backup in Settings</p></figcaption></figure>
@@ -97,7 +97,7 @@ _Click on the above image to watch an explanation video on Twitter_
 
 In the app, navigate to `Settings` and proceed to `Vault Settings`.\
 Select `Backup`, enter an optional backup encryption password and proceed with `Save`.\
-If not needed, save the vault share by pressing `Skip PAssword` directly.
+If not needed, save the vault share by pressing `Skip Password` directly.
 
 ***
 

--- a/vultisig-vault-user-actions/managing-your-vault/vault-qr.md
+++ b/vultisig-vault-user-actions/managing-your-vault/vault-qr.md
@@ -13,7 +13,7 @@ It is only a tool to share public keys easily and securely.
 
 ## Why it is needed?
 
-With the Vault QR, the public keys of a Vault can be easily imported into other interfaces without the risk of exposing sensitive information, which could lead to loss of funds or potential exploits.&#x20;
+With the Vault QR, the public keys of a Vault can be easily imported into other interfaces without the risk of exposing sensitive information, which could lead to loss of funds or potential exploits.
 
 This is a safe way to share and import Vultisig Vaults without using seed phrases.
 
@@ -25,4 +25,4 @@ You can find the export of the QR code on the main screen in the top right corne
 
 ## Where to use the Vault QR?
 
-Currently the Vault QR can be imported into the Vultisig [Airdrop page](https://airdrop.vultisig.com/), to register for the [airdrop](../../vultisig-token/airdrop/) or into the [Vultisig Connect](broken-reference) browser extension.
+Currently the Vault QR can be imported into the Vultisig [Airdrop page](https://airdrop.vultisig.com/), to register for the [airdrop](../../vultisig-token/airdrop/) or into the [Vultisig Extension](../../vultisig-ecosystem/vulticonnect/README.md) browser extension.


### PR DESCRIPTION
  - fix typo in FAQ
  - fix vault-backup typo ("PAssword" to "Password")
  - Standardized "Vultisig Extension" wording throughout docs (previously "Vulticonnect/Vultisig Connect") for clarity
  - fix broken reference to Vultisig Extension
  - fix broken reference to Vultisig Extension airdrop instructions
  - remove unnecessary HTML entity from `vault-qr.md`