### PR TITLE
fix: add redirects for legacy docs URLs

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -57,5 +57,5 @@ redirects:
   # Legacy top-level paths -> new structure
   security-technology: security-and-technology/overview.md
   other/micar-white-paper: help/micar-white-paper.md
-  threshold-signature-scheme/security: help/security.md
+  threshold-signature-scheme/security: security-and-technology/overview.md
   threshold-signature-scheme/emergency-recovery: security-and-technology/emergency-recovery.md


### PR DESCRIPTION
## Summary
- Redirect legacy docs paths to their current destinations
- Fix dead backlinks for security, MiCAR, and emergency recovery URLs

## Notes
- /security-technology -> security-and-technology overview
- /other/micar-white-paper -> help/micar-white-paper
- /threshold-signature-scheme/security -> security-and-technology overview
- /threshold-signature-scheme/emergency-recovery -> security-and-technology emergency recovery

## Verification
- Updated GitBook redirect map in .gitbook.yaml