### PR TITLE
[codex] fix verified documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,6 @@ These are the most common configurations, but Vultisig supports a wide range of 
 
 ## Community
 
-* **Discord**: [discord.vultisig.com](https://discord.vultisig.com)
+* **Discord**: [discord.gg/Cugw9T2NrP](https://discord.gg/Cugw9T2NrP)
 * **Twitter/X**: [@vultisig](https://x.com/vultisig)
 * **GitHub**: [github.com/vultisig](https://github.com/vultisig)

--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -62,5 +62,5 @@ New to Vultisig's architecture? These resources explain the underlying security 
 
 Questions or need help getting started? Join our developer community:
 
-* **Discord**: [discord.gg/vultisig](https://discord.gg/vultisig) - Dedicated third-party developer section
+* **Discord**: [discord.gg/Cugw9T2NrP](https://discord.gg/Cugw9T2NrP) - Dedicated third-party developer section
 * **GitHub**: [github.com/vultisig](https://github.com/vultisig) - Source code and issue tracking

--- a/developer-docs/marketplace/README.md
+++ b/developer-docs/marketplace/README.md
@@ -33,5 +33,5 @@ Each plugin is an independent service — you define your own recipe (transactio
 
 ## Support
 
-- **Discord**: [discord.gg/vultisig](https://discord.gg/vultisig) - Join the third-party developer section
+- **Discord**: [discord.gg/Cugw9T2NrP](https://discord.gg/Cugw9T2NrP) - Join the third-party developer section
 - **GitHub**: [github.com/vultisig](https://github.com/vultisig) - Source code and issues

--- a/developer-docs/marketplace/create-a-plugin/basics-quick-start.md
+++ b/developer-docs/marketplace/create-a-plugin/basics-quick-start.md
@@ -89,7 +89,7 @@ The specification defines what your plugin does and how it appears in the Vultis
 * `ValidatePluginPolicy()`: Validates user input against your schema
 * `Suggest()`: Converts user configuration into specific execution rules with constraints
 
-**Full example**: [Specifications](build-your-app/hello-world/server/spec.go)
+**Full example**: [Specifications](build-your-plugin/hello-world/server/spec.go)
 
 ***
 
@@ -122,7 +122,7 @@ Running the worker separately from the server provides:
 * Registers handlers for `TypeKeySignDKLS` and `TypeReshareDKLS` tasks
 * Processes tasks with configurable concurrency (default: 10 parallel tasks)
 
-**Full example**: [Worker](build-your-app/hello-world/worker/worker.go)
+**Full example**: [Worker](build-your-plugin/hello-world/worker/worker.go)
 
 ***
 

--- a/developer-docs/marketplace/create-a-plugin/submission-process.md
+++ b/developer-docs/marketplace/create-a-plugin/submission-process.md
@@ -62,7 +62,7 @@ plugins:
 {% step %}
 #### Join the developer discord
 
-Join Discord at [discord.gg/vultisig](https://discord.gg/vultisig), navigate to dedicated section for third-party developers and get real-time support and feedback from the Vultisig team while building your plugin
+Join Discord at [discord.gg/Cugw9T2NrP](https://discord.gg/Cugw9T2NrP), navigate to dedicated section for third-party developers and get real-time support and feedback from the Vultisig team while building your plugin
 {% endstep %}
 
 {% step %}

--- a/developer-docs/marketplace/plugins/submission-process.md
+++ b/developer-docs/marketplace/plugins/submission-process.md
@@ -48,7 +48,7 @@ plugins:
 
 ## Submission Process
 
-1. Join Discord at [discord.gg/vultisig](https://discord.gg/vultisig), navigate to dedicated section for third-party developers and get real-time support and feedback from the Vultisig team
+1. Join Discord at [discord.gg/Cugw9T2NrP](https://discord.gg/Cugw9T2NrP), navigate to dedicated section for third-party developers and get real-time support and feedback from the Vultisig team
 2. Prepare your submission package: YAML config and documentation.
 3. Complete the security checklist and performance requirements for APIs and resource use.
 

--- a/developer-docs/vultisig-sdk.md
+++ b/developer-docs/vultisig-sdk.md
@@ -161,7 +161,7 @@ See the [Quick Reference](vultisig-sdk.md#supported-chains) section for the comp
 
 By default, the SDK uses in-memory storage (data is lost on restart). For persistence:
 
-* **Browser**: Use IndexedDB storage (see [examples/browser](examples/browser/))
+* **Browser**: Use IndexedDB storage (see [examples/browser](https://github.com/vultisig/vultisig-sdk/tree/main/examples/browser))
 * **Node.js**: Implement file-based storage or use a database
 * **Custom**: Implement the `Storage` interface
 
@@ -1488,7 +1488,7 @@ cp node_modules/@vultisig/sdk/dist/*.wasm public/
 # Next.js: place in public/ directory
 ```
 
-**IndexedDB Storage**: For persistent storage, use IndexedDB (see [examples/browser](examples/browser/) for implementation).
+**IndexedDB Storage**: For persistent storage, use IndexedDB (see [examples/browser](https://github.com/vultisig/vultisig-sdk/tree/main/examples/browser) for implementation).
 
 **Import**:
 
@@ -1535,8 +1535,8 @@ sdk.dispose()
 ## Additional Resources
 
 * **Examples**:
-  * [Browser Example](examples/browser/) - Full React app with UI
-  * [CLI](clients/cli/) - Command-line wallet with interactive shell mode
+  * [Browser Example](https://github.com/vultisig/vultisig-sdk/tree/main/examples/browser) - Full React app with UI
+  * [CLI](https://github.com/vultisig/vultisig-sdk/tree/main/clients/cli) - Command-line wallet with interactive shell mode
 * **GitHub**: [vultisig-sdk](https://github.com/vultisig/vultisig-sdk)
 * **Issues**: Report bugs and request features on GitHub
 

--- a/developer-docs/vultisig-sdk/CLI.md
+++ b/developer-docs/vultisig-sdk/CLI.md
@@ -877,13 +877,13 @@ npm update -g @vultisig/cli
 
 ## Documentation
 
-- [SDK Documentation](../../packages/sdk/README.md)
+- [SDK Documentation](https://github.com/vultisig/vultisig-sdk/blob/main/packages/sdk/README.md)
 - [API Reference](https://docs.vultisig.com)
 
 ## Support
 
 - [GitHub Issues](https://github.com/vultisig/vultisig-sdk/issues)
-- [Discord](https://discord.gg/vultisig)
+- [Discord](https://discord.gg/Cugw9T2NrP)
 - [Documentation](https://docs.vultisig.com)
 
 ## License

--- a/developer-docs/vultisig-sdk/README.md
+++ b/developer-docs/vultisig-sdk/README.md
@@ -921,12 +921,12 @@ packages/lib/          # Shared libraries and utilities
 
 ## License
 
-MIT License - see [LICENSE](./LICENSE) file for details.
+MIT License - see the [SDK LICENSE](https://github.com/vultisig/vultisig-sdk/blob/main/packages/sdk/LICENSE) file for details.
 
 ## Support
 
 - 📖 [Documentation](https://docs.vultisig.com)
-- 💬 [Discord Community](https://discord.gg/vultisig)
+- 💬 [Discord Community](https://discord.gg/Cugw9T2NrP)
 - 🐛 [Report Issues](https://github.com/vultisig/vultisig-sdk/issues)
 - 🌐 [Website](https://vultisig.com)
 

--- a/developer-docs/vultisig-sdk/SDK-USERS-GUIDE.md
+++ b/developer-docs/vultisig-sdk/SDK-USERS-GUIDE.md
@@ -2975,7 +2975,7 @@ cp node_modules/@vultisig/sdk/dist/*.wasm public/
 # Next.js: place in public/ directory
 ```
 
-**IndexedDB Storage**: For persistent storage, use IndexedDB (see [examples/browser](../examples/browser) for implementation).
+**IndexedDB Storage**: For persistent storage, use IndexedDB (see [examples/browser](https://github.com/vultisig/vultisig-sdk/tree/main/examples/browser) for implementation).
 
 **Import**:
 
@@ -3122,8 +3122,8 @@ Include WASM files in your Electron build:
 ## Additional Resources
 
 - **Examples**:
-  - [Browser Example](../examples/browser) - Full React app with UI
-  - [CLI](../clients/cli) - Command-line wallet with interactive shell mode
+  - [Browser Example](https://github.com/vultisig/vultisig-sdk/tree/main/examples/browser) - Full React app with UI
+  - [CLI](https://github.com/vultisig/vultisig-sdk/tree/main/clients/cli) - Command-line wallet with interactive shell mode
 
 - **GitHub**: [vultisig-sdk](https://github.com/vultisig/vultisig-sdk)
 - **Issues**: Report bugs and request features on GitHub

--- a/help/README.md
+++ b/help/README.md
@@ -48,7 +48,7 @@ This section provides support resources and legal documentation for Vultisig use
 
 ## Community
 
-* **Discord**: [discord.vultisig.com](https://discord.vultisig.com)
+* **Discord**: [discord.gg/Cugw9T2NrP](https://discord.gg/Cugw9T2NrP)
 * **Twitter/X**: [@vultisig](https://x.com/vultisig)
 * **GitHub**: [github.com/vultisig](https://github.com/vultisig)
 

--- a/help/faq.md
+++ b/help/faq.md
@@ -130,7 +130,7 @@ Your funds remain accessible. Vultisig provides [emergency recovery tools](../se
 1. Force close and restart the app
 2. Check for app updates
 3. Restart device if issue persists
-4. Report persistent issues on [GitHub](https://github.com/vultisig/vultisig-ios/issues) or [Discord](https://discord.vultisig.com)
+4. Report persistent issues on [GitHub](https://github.com/vultisig/vultisig-ios/issues) or [Discord](https://discord.gg/Cugw9T2NrP)
 
 ***
 

--- a/help/privacy.md
+++ b/help/privacy.md
@@ -135,7 +135,7 @@ We may update this policy periodically. Significant changes will be communicated
 For privacy-related inquiries:
 
 - **Email**: privacy@vultisig.com
-- **Discord**: [discord.vultisig.com](https://discord.vultisig.com)
+- **Discord**: [discord.gg/Cugw9T2NrP](https://discord.gg/Cugw9T2NrP)
 
 ***
 

--- a/help/terms.md
+++ b/help/terms.md
@@ -148,7 +148,7 @@ If any provision of these Terms is found unenforceable, the remaining provisions
 For questions about these Terms:
 
 - **Email**: legal@vultisig.com
-- **Discord**: [discord.vultisig.com](https://discord.vultisig.com)
+- **Discord**: [discord.gg/Cugw9T2NrP](https://discord.gg/Cugw9T2NrP)
 
 ***
 

--- a/vultisig-ecosystem/marketplace.md
+++ b/vultisig-ecosystem/marketplace.md
@@ -166,7 +166,7 @@ Build plugins for Vultisig users and earn 70% of the revenue. Plugins are review
 - Cross-chain workflows
 
 {% hint style="info" %}
-Ready to build? Check the [Developer Documentation](../developer-docs/marketplace/) for Plugins and join [Discord](https://discord.gg/vultisig) for support.
+Ready to build? Check the [Developer Documentation](../developer-docs/marketplace/) for Plugins and join [Discord](https://discord.gg/Cugw9T2NrP) for support.
 {% endhint %}
 
 ***
@@ -318,4 +318,4 @@ The Marketplace is actively growing. Upcoming features include:
 - Community-built tools
 - Enhanced analytics and reporting
 
-Want to request a plugin or feature? Join the [Discord](https://discord.gg/vultisig) and share your ideas.
+Want to request a plugin or feature? Join the [Discord](https://discord.gg/Cugw9T2NrP) and share your ideas.

--- a/vultisig-ecosystem/vultisig-extension/web3-support.md
+++ b/vultisig-ecosystem/vultisig-extension/web3-support.md
@@ -19,7 +19,6 @@ This it the current list of supported dApps and interfaces:
 | [LeoDex](https://leodex.io/)                                                 | [Magic Eden](https://magiceden.io/) | [Venice.ai](https://venice.ai/)    |
 | [SushiSwap](https://app.sushi.com/)                                          | [Rarible](https://rarible.com/)     |                                    |
 | [ShapeShift](https://app.shapeshift.com/)                                    |                                     |                                    |
-| [DeFiSpot](https://www.defispot.com/tokens/ETH.ETH?from=BTC.BTC\&to=ETH.ETH) |                                     |                                    |
 | [1inch](https://app.1inch.io/)                                               |                                     |                                    |
 | [KyberSwap](https://kyberswap.com/)                                          |                                     |                                    |
 | [Trader Joe](https://traderjoexyz.com/)                                      |                                     |                                    |


### PR DESCRIPTION
## What changed

- replace dead `discord.vultisig.com` and invalid `discord.gg/vultisig` links with the confirmed main-server invite supplied by the project owner: `discord.gg/Cugw9T2NrP`
- remove the dead DeFiSpot listing
- correct two plugin example paths after the `build-your-app` to `build-your-plugin` restructure
- point SDK example, CLI, README, and license links at verified locations in `vultisig/vultisig-sdk`

## Validation

- Discord API confirms `Cugw9T2NrP` resolves to guild `Vultisig` (`1203844257220395078`), described as “The official Vultisig discord”
- Discord API confirms `discord.gg/vultisig` is an unknown invite
- verified all replacement GitHub URLs return HTTP 200
- verified corrected plugin example files exist in this repository
- `git diff --check`

## Not changed

- no replacement was guessed for `airdrop.vultisig.com`
- no RSS endpoints were added
- external bot-blocked or rate-limited links were left untouched
