### PR TITLE
[codex] Add dedicated AI agents documentation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -80,6 +80,9 @@
 ## Developer Docs
 
 * [Developer Home](developer-docs/README.md)
+* [AI Agents](developer-docs/ai-agents/README.md)
+  * [Authority and Security](developer-docs/ai-agents/authority-and-security.md)
+  * [Integration Options](developer-docs/ai-agents/integration-options.md)
 * [Marketplace Plugins](developer-docs/marketplace/README.md)
   * [What is a Plugin](developer-docs/marketplace/infrastructure-overview/plugins.md)
   * [Services Architecture](developer-docs/marketplace/infrastructure-overview/services.md)

--- a/agent.md
+++ b/agent.md
@@ -1,137 +1,208 @@
 ---
 description: >-
-  Give AI agents multi-chain wallet capabilities with a choice of autonomous,
-  policy-bound, or human-approved signing.
+  Structured index of Vultisig documentation for AI agents and language models.
+  SDK and CLI focus.
 ---
 
-# Agent capabilities with Vultisig
+# For AI Agents
 
-Vultisig gives agents a programmable, seedless wallet across 40+ blockchains. Agents can inspect a portfolio, prepare transactions, send assets, swap across chains, and sign messages without ever holding a complete private key.
+> Vultisig: Seedless, multi-chain, self-custody wallet using TSS/MPC. TypeScript SDK and CLI for building AI agents, automated plugins, and crypto applications across 40+ blockchains.
 
-The important choice is not whether an agent can transact. It is **how much authority the agent should have**. Vultisig supports three operating models, from full runtime autonomy to human approval on every signature.
+## SDK (`@vultisig/sdk`)
 
-## Choose the right operating model
+TypeScript SDK for MPC vault creation, signing, balance checks, swaps, and transaction management.
 
-| Operating model | Best for | How signing works | Start with |
-| --- | --- | --- | --- |
-| **Autonomous Fast Vault** | Bots, services, and agents that must transact without a person present | The agent's device and VultiServer form a 2-of-2 MPC vault. Signing is immediate. | [SDK](developer-docs/vultisig-sdk/) or [CLI](developer-docs/vultisig-sdk/CLI.md) |
-| **Policy-bound automation** | Recurring workflows and autonomous strategies with defined limits | A Marketplace plugin proposes transactions. A separate Verifier signs only when the proposal matches the user's configured rules. | [Plugin Marketplace](vultisig-ecosystem/marketplace.md) |
-| **Human-approved Secure Vault** | Higher-value or sensitive workflows where a person should approve every transaction | The agent prepares the action, then the configured threshold of devices joins the MPC signing session. | [SDK implementation guide](developer-docs/vultisig-sdk/SDK-USERS-GUIDE.md) |
+**Install:** `npm install @vultisig/sdk`
 
-These models can support the same agent experience while placing the final signing authority in different places. Use the least authority that still lets the workflow succeed.
-
-## Pick the integration surface
-
-### CLI: give an existing agent a wallet
-
-Use the Vultisig CLI when an agent can run shell commands. It exposes structured JSON output, non-interactive options, quote commands, and specific exit codes for reliable agent workflows.
-
-```bash
-npm install -g @vultisig/cli
-
-# Read-only portfolio snapshot
-vultisig portfolio --output json
-
-# Preview a cross-chain swap quote
-vultisig swap-quote ethereum bitcoin 0.1 --output json
-
-# Execute a cross-chain swap
-vultisig swap ethereum bitcoin 0.1 --output json
-```
-
-See the [CLI reference](developer-docs/vultisig-sdk/CLI.md) for vault creation, environment variables, commands, and JSON output.
-
-### SDK: build wallet capabilities into an agent
-
-Use `@vultisig/sdk` when you are building a TypeScript agent, bot, or application. The SDK handles vault creation, balances, portfolio tracking, sends, swaps, message signing, and transaction broadcasting.
+**Core flow:** Initialize → Create vault → Verify → Use
 
 ```typescript
-import { Chain, Vultisig } from '@vultisig/sdk'
+import { Vultisig, MemoryStorage } from '@vultisig/sdk'
 
-const sdk = new Vultisig()
+const sdk = new Vultisig({ storage: new MemoryStorage() })
 await sdk.initialize()
 
-const vault = await sdk.getActiveVault()
-if (!vault) throw new Error('No active vault')
+const vaultId = await sdk.createFastVault({ name: 'Agent Wallet', email: 'agent@example.com', password: 'pass' })
+const vault = await sdk.verifyVault(vaultId, code)
 
-const portfolio = await vault.portfolio('usd')
-const preview = await vault.send({
-  chain: Chain.Ethereum,
-  to: '0xRecipient',
-  amount: '0.1',
-  dryRun: true,
-})
+const address = await vault.address('Ethereum')
+const balance = await vault.balance('Ethereum')
 ```
 
-Start with the [SDK guide](developer-docs/vultisig-sdk/) and [implementation guide](developer-docs/vultisig-sdk/SDK-USERS-GUIDE.md).
+**Key methods:**
 
-### Marketplace: publish policy-bound automation
+| Method                                  | What it does                                           |
+| --------------------------------------- | ------------------------------------------------------ |
+| `sdk.createFastVault(opts)`             | Create 2-of-2 vault with VultiServer (instant signing) |
+| `sdk.createSecureVault(opts)`           | Create N-of-M multi-device vault (human co-signing)    |
+| `sdk.verifyVault(vaultId, code)`        | Verify vault via email code, returns vault             |
+| `vault.address(chain)`                  | Derive address for a chain                             |
+| `vault.balance(chain)`                  | Get native balance                                     |
+| `vault.balances(chains, includeTokens)` | Get balances across chains                             |
+| `vault.prepareSendTx(params)`           | Prepare a send transaction                             |
+| `vault.sign(payload)`                   | Sign a transaction (MPC)                               |
+| `vault.broadcastTx(params)`             | Broadcast signed transaction                           |
+| `vault.gas(chain)`                      | Get gas/fee estimate                                   |
+| `vault.getSwapQuote(params)`            | Get swap quote (THORChain, 1inch, LiFi)                |
+| `vault.prepareSwapTx(params)`           | Prepare swap transaction (handles approval)            |
+| `vault.signBytes(opts)`                 | Sign arbitrary pre-hashed bytes                        |
+| `vault.broadcastRawTx(params)`          | Broadcast pre-signed raw transaction                   |
+| `sdk.importVault(content, password)`    | Import vault from `.vult` file                         |
+| `vault.export(password)`                | Export vault to backup                                 |
 
-Use a Marketplace plugin when an agent should act within user-defined rules rather than receive broad wallet authority. The plugin proposes an unsigned transaction; an independent Verifier checks the destination, amount, timing, and other configured rules before participating in MPC signing.
+**Vault types:**
 
-This model is designed for workflows such as recurring swaps, payments, portfolio rebalancing, and condition-based strategies. Learn about the [Plugin Marketplace](vultisig-ecosystem/marketplace.md) or [build a plugin](developer-docs/marketplace/).
+|                    | Fast Vault                | Secure Vault                        |
+| ------------------ | ------------------------- | ----------------------------------- |
+| **Threshold**      | 2-of-2 (with VultiServer) | N-of-M (configurable)               |
+| **Signing**        | Instant, no human needed  | Requires device coordination via QR |
+| **Agent use case** | Full autonomy             | Human oversight on every tx         |
 
-## What agents can do
+**Supported chains (36+):** Bitcoin, Ethereum, Solana, THORChain, Polygon, Arbitrum, Optimism, Base, BSC, Avalanche, Cosmos, Litecoin, Dogecoin, Sui, TON, Ripple, Tron, Polkadot, Cardano, and more.
 
-### Read-only portfolio intelligence
+**Full docs:**
 
-> "Summarize my portfolio across Bitcoin, Ethereum, Solana, and Cosmos."
+* [SDK README](developer-docs/vultisig-sdk/): Installation, quick start, API reference, vault types, error handling
+* [SDK Implementation Guide](developer-docs/vultisig-sdk/SDK-USERS-GUIDE.md): Complete usage guide — password management, vault lifecycle, transactions, swaps, events, caching, platform notes
 
-The agent queries addresses, native and token balances, and fiat values without signing a transaction.
+***
 
-### Preview, then execute
+## CLI (`@vultisig/cli`)
 
-> "Prepare a 0.1 ETH transfer, show me the fee and total, then wait for approval."
+Command-line wallet for scripting, automation, and agent pipelines. Mirrors the SDK's full capabilities.
 
-The agent uses a dry run to surface the expected cost and transaction details before entering the selected signing flow.
+**Install:** `npm install -g @vultisig/cli`
 
-### Natural-language cross-chain swaps
+**Key commands:**
 
-> "Swap 0.1 ETH to BTC using the best available route."
+```bash
+# Vault management
+vultisig create fast --name "Wallet" --email user@example.com --password pass
+vultisig create secure --name "Team Wallet" --shares 3
+vultisig import /path/to/vault.vult
+vultisig vaults
+vultisig export
 
-The agent can request a quote, explain estimated output and fees, then execute through THORChain, 1inch, KyberSwap, LiFi, or another supported route.
+# Balances & addresses
+vultisig balance                      # All chains
+vultisig balance ethereum --tokens    # Specific chain + tokens
+vultisig addresses
+vultisig portfolio
 
-### Policy-bound automation
+# Transactions
+vultisig send ethereum 0xRecipient 0.1
+vultisig send ethereum 0xRecipient 100 --token 0xTokenAddress
 
-> "Rebalance when BTC moves outside 45-55% of the portfolio, but never trade more than $500 per day."
+# Swaps
+vultisig swap-quote ethereum bitcoin 0.1
+vultisig swap ethereum bitcoin 0.1
 
-A Marketplace agent can monitor conditions and propose transactions while the Verifier enforces the rules configured by the user.
+# Advanced: sign arbitrary bytes, broadcast raw tx
+vultisig sign --chain ethereum --bytes "base64hash" -o json
+vultisig broadcast --chain ethereum --raw-tx "0x02f8..."
 
-## The security boundary
+# Seedphrase import
+vultisig create-from-seedphrase fast --name "Imported" --email user@example.com --discover-chains
+```
 
-Vultisig removes the complete private key as a single point of failure, but MPC does not make an agent's decisions correct. Your application is still responsible for prompts, strategy logic, token and contract selection, transaction parameters, credential storage, and economic outcomes.
+**Agent-friendly features:**
 
-Before allowing an agent to sign:
+* `--output json` (or `-o json`) — structured JSON for all commands
+* `--silent` — suppress spinners and progress messages
+* `--password` flag — avoid interactive prompts
+* `VAULT_PASSWORD` env var — for automation pipelines
+* `VULTISIG_VAULT` env var — pre-select vault by name or ID
+* Exit codes: 0 success, 1-7 for specific error types
+* `vsig` shorthand alias for `vultisig`
 
-* Use dry runs and surface the destination, assets, fees, and expected output.
-* Prefer a Secure Vault when every transaction needs human approval.
-* Prefer Marketplace policies when autonomy should be limited by explicit rules.
-* Protect vault passwords and backups; do not embed them in prompts, source code, or logs.
-* Treat arbitrary message and byte signing as high-risk capabilities.
+**Full docs:** [CLI Documentation](developer-docs/vultisig-sdk/CLI.md): All commands, options, environment variables, JSON output examples, exit codes, interactive shell
 
-{% hint style="warning" %}
-Fast Vaults enable unattended signing. Only fund an autonomous vault with an amount appropriate for the workflow's risk, and keep a tested vault backup.
-{% endhint %}
+***
 
-## Agent discovery
+## Agent Resources
 
-Vultisig publishes machine-readable resources for agents and coding assistants:
+Files on [vultisig.com](https://vultisig.com) for agent discovery and integration:
 
-| Resource | Purpose |
-| --- | --- |
-| [SKILL.md](https://vultisig.com/SKILL.md) | Operating instructions for balances, sends, swaps, gas estimation, and vault workflows |
-| [llms.txt](https://vultisig.com/llms.txt) | Compact documentation index |
-| [llms-full.txt](https://vultisig.com/llms-full.txt) | Full SDK context and examples |
-| [agent.json](https://vultisig.com/.well-known/agent.json) | Structured capabilities manifest |
-| [MCP server](https://github.com/vultisig/mcp) | Experimental MCP tools for EVM reads and transaction building |
+| File                                                      | What it is                                                                                          |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| [SKILL.md](https://vultisig.com/SKILL.md)                 | Full operating procedure — 14 steps covering vault creation, sends, swaps, balances, gas estimation |
+| [llms.txt](https://vultisig.com/llms.txt)                 | Spec-compliant link index (llmstxt.org format)                                                      |
+| [llms-full.txt](https://vultisig.com/llms-full.txt)       | Full SDK context with verified code examples and source references                                  |
+| [agent.json](https://vultisig.com/.well-known/agent.json) | Structured capabilities manifest — chains, operations, SDK info                                     |
 
-{% hint style="info" %}
-The MCP server is a work in progress. For production wallet operations, use the SDK, CLI, or Marketplace plugin infrastructure.
-{% endhint %}
+***
 
-## Get started
+## Documentation Index
 
-* **Give an existing coding agent a wallet:** install the [CLI](developer-docs/vultisig-sdk/CLI.md).
-* **Build a long-running agent or bot:** integrate the [TypeScript SDK](developer-docs/vultisig-sdk/).
-* **Build constrained autonomous strategies:** start with the [Marketplace developer docs](developer-docs/marketplace/).
-* **Require a person to approve every signature:** use a [Secure Vault](app-guide/creating-a-vault/secure-vault.md).
+### Getting Started
+
+* [Overview](./): What Vultisig is, key features
+* [Download & Install](getting-started/download-install.md): iOS, Android, macOS, Windows, Linux, browser extension
+* [Create a Vault](getting-started/create-vault.md): Fast Vault and Secure Vault creation
+* [Backup & Recovery](getting-started/backup-recovery.md): Vault backup and restore
+* [Your First Transaction](getting-started/first-transaction.md): Send your first transaction
+
+### App Guide
+
+* [Vault Creation](app-guide/creating-a-vault/): Vault types and flows
+  * [Fast Vault](app-guide/creating-a-vault/fast-vault.md): 2-of-2 with VultiServer
+  * [Secure Vault](app-guide/creating-a-vault/secure-vault.md): Multi-device with QR pairing
+* [Sending](app-guide/wallet/sending.md): How to send tokens
+* [Swapping](app-guide/wallet/swapping.md): Cross-chain and same-chain swaps
+* [DeFi](app-guide/defi/): Circle Protocol, THORChain, MayaChain, staking
+* [Vault Management](app-guide/vault-management/): Details, backups, reshare, rename, upgrade
+
+### Security & Technology
+
+* [Overview](security-and-technology/overview.md): Security architecture
+* [Keysign](security-and-technology/keysign.md): Transaction signing
+* [TSS Actions](security-and-technology/tss-actions.md): Threshold signature operations
+* [How GG20 Works](security-and-technology/how-gg20-works.md): GG20 protocol
+* [How DKLS23 Works](security-and-technology/how-dkls23-works.md): DKLS23 protocol
+* [Difference to Multi-Signatures](security-and-technology/difference-to-multi-sig.md): TSS vs multisig
+* [Emergency Recovery](security-and-technology/emergency-recovery.md): Recovery procedures
+
+### Ecosystem
+
+* [Vultisig Extension](vultisig-ecosystem/vultisig-extension/): Browser extension for dApps
+* [Plugin Marketplace](vultisig-ecosystem/marketplace.md): Self-custodial automation — plugins and AI agents
+* [Web App](vultisig-ecosystem/web-app.md): Browser-based vault access
+* [Vultisig SDK](vultisig-ecosystem/vultisig-sdk.md): SDK overview with agent section
+* [Community Tools](vultisig-ecosystem/community-tools.md): Third-party tools
+
+### VULT Token
+
+* [The $VULT Token](vultisig-token/vult/): Tokenomics and utility
+* [In-App Utility](vultisig-token/vult/in-app-utility.md): Fee discounts, staking tiers
+* [Marketplace Utility](vultisig-token/vult/marketplace-utility.md): Revenue distribution
+* [Governance](vultisig-token/vult/governance-utility.md): Voting rights
+
+### Infrastructure
+
+* [Overview](vultisig-infrastructure/overview.md): Architecture
+* [Vultiserver](vultisig-infrastructure/what-is-vultisigner/): Co-signing server for Fast Vaults
+* [Transaction Policies](vultisig-infrastructure/what-is-vultisigner/what-can-be-configured.md): Spending limits, whitelists, time delays
+* [Relay Server](vultisig-infrastructure/relay-server.md): Device session coordination
+
+### Developer Docs
+
+* [Developer Home](developer-docs/): Entry point
+* [Marketplace Plugins](developer-docs/marketplace/): Build and publish plugins
+  * [What is a Plugin](developer-docs/marketplace/infrastructure-overview/plugins.md): Architecture and scope
+  * [Services Architecture](developer-docs/marketplace/infrastructure-overview/services.md): Service components
+  * [Policy Rules](developer-docs/marketplace/infrastructure-overview/metarules.md): Transaction validation rules
+  * [Infrastructure](developer-docs/marketplace/infrastructure-overview/infrastructure.md): Plugin infrastructure
+  * [Quick Start](developer-docs/marketplace/create-a-plugin/basics-quick-start.md): Scaffold your first plugin
+  * [Build Your Plugin](developer-docs/marketplace/create-a-plugin/build-your-plugin/): Full development guide
+  * [Submission & Revenue](developer-docs/marketplace/create-a-plugin/submission-process.md): Review process, 70/30 split
+* [Extension Integration](developer-docs/vultisig-extension-integration-guide.md): window.vultisig API, code examples
+* [SDK](developer-docs/vultisig-sdk/): Full SDK docs
+  * [SDK Implementation Guide](developer-docs/vultisig-sdk/SDK-USERS-GUIDE.md): Detailed usage guide
+  * [SDK CLI](developer-docs/vultisig-sdk/CLI.md): CLI reference
+
+### Help & Legal
+
+* [FAQ](help/faq.md): Common questions
+* [Security](help/security.md): Security policy
+* [Privacy](help/privacy.md): Privacy policy
+* [Terms of Use](help/terms.md): Terms

--- a/agent.md
+++ b/agent.md
@@ -97,6 +97,10 @@ vultisig send ethereum 0xRecipient 100 --token 0xTokenAddress
 vultisig swap-quote ethereum bitcoin 0.1
 vultisig swap ethereum bitcoin 0.1
 
+# Natural-language, one-shot — built for AI agent integration
+vultisig agent ask "What is my ETH balance?" --password "$VAULT_PASSWORD" --json
+vultisig agent ask "Send 0.01 ETH to 0x742d..." --session abc123 --password "$VAULT_PASSWORD"
+
 # Advanced: sign arbitrary bytes, broadcast raw tx
 vultisig sign --chain ethereum --bytes "base64hash" -o json
 vultisig broadcast --chain ethereum --raw-tx "0x02f8..."
@@ -107,6 +111,9 @@ vultisig create-from-seedphrase fast --name "Imported" --email user@example.com 
 
 **Agent-friendly features:**
 
+* `agent ask "<message>"` — one-shot natural-language mode for AI-to-AI use; returns structured JSON with `--json` and stable error codes
+* Non-interactive (non-TTY) auto-detection — skips prompts that would hang an agent; vault creation falls back to two-step mode automatically
+* `--ci` — full automation mode (`--output json --non-interactive --quiet`)
 * `--output json` (or `-o json`) — structured JSON for all commands
 * `--silent` — suppress spinners and progress messages
 * `--password` flag — avoid interactive prompts

--- a/agent.md
+++ b/agent.md
@@ -1,208 +1,137 @@
 ---
 description: >-
-  Structured index of Vultisig documentation for AI agents and language models.
-  SDK and CLI focus.
+  Give AI agents multi-chain wallet capabilities with a choice of autonomous,
+  policy-bound, or human-approved signing.
 ---
 
-# For AI Agents
+# Agent capabilities with Vultisig
 
-> Vultisig: Seedless, multi-chain, self-custody wallet using TSS/MPC. TypeScript SDK and CLI for building AI agents, automated plugins, and crypto applications across 40+ blockchains.
+Vultisig gives agents a programmable, seedless wallet across 40+ blockchains. Agents can inspect a portfolio, prepare transactions, send assets, swap across chains, and sign messages without ever holding a complete private key.
 
-## SDK (`@vultisig/sdk`)
+The important choice is not whether an agent can transact. It is **how much authority the agent should have**. Vultisig supports three operating models, from full runtime autonomy to human approval on every signature.
 
-TypeScript SDK for MPC vault creation, signing, balance checks, swaps, and transaction management.
+## Choose the right operating model
 
-**Install:** `npm install @vultisig/sdk`
+| Operating model | Best for | How signing works | Start with |
+| --- | --- | --- | --- |
+| **Autonomous Fast Vault** | Bots, services, and agents that must transact without a person present | The agent's device and VultiServer form a 2-of-2 MPC vault. Signing is immediate. | [SDK](developer-docs/vultisig-sdk/) or [CLI](developer-docs/vultisig-sdk/CLI.md) |
+| **Policy-bound automation** | Recurring workflows and autonomous strategies with defined limits | A Marketplace plugin proposes transactions. A separate Verifier signs only when the proposal matches the user's configured rules. | [Plugin Marketplace](vultisig-ecosystem/marketplace.md) |
+| **Human-approved Secure Vault** | Higher-value or sensitive workflows where a person should approve every transaction | The agent prepares the action, then the configured threshold of devices joins the MPC signing session. | [SDK implementation guide](developer-docs/vultisig-sdk/SDK-USERS-GUIDE.md) |
 
-**Core flow:** Initialize → Create vault → Verify → Use
+These models can support the same agent experience while placing the final signing authority in different places. Use the least authority that still lets the workflow succeed.
 
-```typescript
-import { Vultisig, MemoryStorage } from '@vultisig/sdk'
+## Pick the integration surface
 
-const sdk = new Vultisig({ storage: new MemoryStorage() })
-await sdk.initialize()
+### CLI: give an existing agent a wallet
 
-const vaultId = await sdk.createFastVault({ name: 'Agent Wallet', email: 'agent@example.com', password: 'pass' })
-const vault = await sdk.verifyVault(vaultId, code)
-
-const address = await vault.address('Ethereum')
-const balance = await vault.balance('Ethereum')
-```
-
-**Key methods:**
-
-| Method                                  | What it does                                           |
-| --------------------------------------- | ------------------------------------------------------ |
-| `sdk.createFastVault(opts)`             | Create 2-of-2 vault with VultiServer (instant signing) |
-| `sdk.createSecureVault(opts)`           | Create N-of-M multi-device vault (human co-signing)    |
-| `sdk.verifyVault(vaultId, code)`        | Verify vault via email code, returns vault             |
-| `vault.address(chain)`                  | Derive address for a chain                             |
-| `vault.balance(chain)`                  | Get native balance                                     |
-| `vault.balances(chains, includeTokens)` | Get balances across chains                             |
-| `vault.prepareSendTx(params)`           | Prepare a send transaction                             |
-| `vault.sign(payload)`                   | Sign a transaction (MPC)                               |
-| `vault.broadcastTx(params)`             | Broadcast signed transaction                           |
-| `vault.gas(chain)`                      | Get gas/fee estimate                                   |
-| `vault.getSwapQuote(params)`            | Get swap quote (THORChain, 1inch, LiFi)                |
-| `vault.prepareSwapTx(params)`           | Prepare swap transaction (handles approval)            |
-| `vault.signBytes(opts)`                 | Sign arbitrary pre-hashed bytes                        |
-| `vault.broadcastRawTx(params)`          | Broadcast pre-signed raw transaction                   |
-| `sdk.importVault(content, password)`    | Import vault from `.vult` file                         |
-| `vault.export(password)`                | Export vault to backup                                 |
-
-**Vault types:**
-
-|                    | Fast Vault                | Secure Vault                        |
-| ------------------ | ------------------------- | ----------------------------------- |
-| **Threshold**      | 2-of-2 (with VultiServer) | N-of-M (configurable)               |
-| **Signing**        | Instant, no human needed  | Requires device coordination via QR |
-| **Agent use case** | Full autonomy             | Human oversight on every tx         |
-
-**Supported chains (36+):** Bitcoin, Ethereum, Solana, THORChain, Polygon, Arbitrum, Optimism, Base, BSC, Avalanche, Cosmos, Litecoin, Dogecoin, Sui, TON, Ripple, Tron, Polkadot, Cardano, and more.
-
-**Full docs:**
-
-* [SDK README](developer-docs/vultisig-sdk/): Installation, quick start, API reference, vault types, error handling
-* [SDK Implementation Guide](developer-docs/vultisig-sdk/SDK-USERS-GUIDE.md): Complete usage guide — password management, vault lifecycle, transactions, swaps, events, caching, platform notes
-
-***
-
-## CLI (`@vultisig/cli`)
-
-Command-line wallet for scripting, automation, and agent pipelines. Mirrors the SDK's full capabilities.
-
-**Install:** `npm install -g @vultisig/cli`
-
-**Key commands:**
+Use the Vultisig CLI when an agent can run shell commands. It exposes structured JSON output, non-interactive options, quote commands, and specific exit codes for reliable agent workflows.
 
 ```bash
-# Vault management
-vultisig create fast --name "Wallet" --email user@example.com --password pass
-vultisig create secure --name "Team Wallet" --shares 3
-vultisig import /path/to/vault.vult
-vultisig vaults
-vultisig export
+npm install -g @vultisig/cli
 
-# Balances & addresses
-vultisig balance                      # All chains
-vultisig balance ethereum --tokens    # Specific chain + tokens
-vultisig addresses
-vultisig portfolio
+# Read-only portfolio snapshot
+vultisig portfolio --output json
 
-# Transactions
-vultisig send ethereum 0xRecipient 0.1
-vultisig send ethereum 0xRecipient 100 --token 0xTokenAddress
+# Preview a cross-chain swap quote
+vultisig swap-quote ethereum bitcoin 0.1 --output json
 
-# Swaps
-vultisig swap-quote ethereum bitcoin 0.1
-vultisig swap ethereum bitcoin 0.1
-
-# Advanced: sign arbitrary bytes, broadcast raw tx
-vultisig sign --chain ethereum --bytes "base64hash" -o json
-vultisig broadcast --chain ethereum --raw-tx "0x02f8..."
-
-# Seedphrase import
-vultisig create-from-seedphrase fast --name "Imported" --email user@example.com --discover-chains
+# Execute a cross-chain swap
+vultisig swap ethereum bitcoin 0.1 --output json
 ```
 
-**Agent-friendly features:**
+See the [CLI reference](developer-docs/vultisig-sdk/CLI.md) for vault creation, environment variables, commands, and JSON output.
 
-* `--output json` (or `-o json`) — structured JSON for all commands
-* `--silent` — suppress spinners and progress messages
-* `--password` flag — avoid interactive prompts
-* `VAULT_PASSWORD` env var — for automation pipelines
-* `VULTISIG_VAULT` env var — pre-select vault by name or ID
-* Exit codes: 0 success, 1-7 for specific error types
-* `vsig` shorthand alias for `vultisig`
+### SDK: build wallet capabilities into an agent
 
-**Full docs:** [CLI Documentation](developer-docs/vultisig-sdk/CLI.md): All commands, options, environment variables, JSON output examples, exit codes, interactive shell
+Use `@vultisig/sdk` when you are building a TypeScript agent, bot, or application. The SDK handles vault creation, balances, portfolio tracking, sends, swaps, message signing, and transaction broadcasting.
 
-***
+```typescript
+import { Chain, Vultisig } from '@vultisig/sdk'
 
-## Agent Resources
+const sdk = new Vultisig()
+await sdk.initialize()
 
-Files on [vultisig.com](https://vultisig.com) for agent discovery and integration:
+const vault = await sdk.getActiveVault()
+if (!vault) throw new Error('No active vault')
 
-| File                                                      | What it is                                                                                          |
-| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| [SKILL.md](https://vultisig.com/SKILL.md)                 | Full operating procedure — 14 steps covering vault creation, sends, swaps, balances, gas estimation |
-| [llms.txt](https://vultisig.com/llms.txt)                 | Spec-compliant link index (llmstxt.org format)                                                      |
-| [llms-full.txt](https://vultisig.com/llms-full.txt)       | Full SDK context with verified code examples and source references                                  |
-| [agent.json](https://vultisig.com/.well-known/agent.json) | Structured capabilities manifest — chains, operations, SDK info                                     |
+const portfolio = await vault.portfolio('usd')
+const preview = await vault.send({
+  chain: Chain.Ethereum,
+  to: '0xRecipient',
+  amount: '0.1',
+  dryRun: true,
+})
+```
 
-***
+Start with the [SDK guide](developer-docs/vultisig-sdk/) and [implementation guide](developer-docs/vultisig-sdk/SDK-USERS-GUIDE.md).
 
-## Documentation Index
+### Marketplace: publish policy-bound automation
 
-### Getting Started
+Use a Marketplace plugin when an agent should act within user-defined rules rather than receive broad wallet authority. The plugin proposes an unsigned transaction; an independent Verifier checks the destination, amount, timing, and other configured rules before participating in MPC signing.
 
-* [Overview](./): What Vultisig is, key features
-* [Download & Install](getting-started/download-install.md): iOS, Android, macOS, Windows, Linux, browser extension
-* [Create a Vault](getting-started/create-vault.md): Fast Vault and Secure Vault creation
-* [Backup & Recovery](getting-started/backup-recovery.md): Vault backup and restore
-* [Your First Transaction](getting-started/first-transaction.md): Send your first transaction
+This model is designed for workflows such as recurring swaps, payments, portfolio rebalancing, and condition-based strategies. Learn about the [Plugin Marketplace](vultisig-ecosystem/marketplace.md) or [build a plugin](developer-docs/marketplace/).
 
-### App Guide
+## What agents can do
 
-* [Vault Creation](app-guide/creating-a-vault/): Vault types and flows
-  * [Fast Vault](app-guide/creating-a-vault/fast-vault.md): 2-of-2 with VultiServer
-  * [Secure Vault](app-guide/creating-a-vault/secure-vault.md): Multi-device with QR pairing
-* [Sending](app-guide/wallet/sending.md): How to send tokens
-* [Swapping](app-guide/wallet/swapping.md): Cross-chain and same-chain swaps
-* [DeFi](app-guide/defi/): Circle Protocol, THORChain, MayaChain, staking
-* [Vault Management](app-guide/vault-management/): Details, backups, reshare, rename, upgrade
+### Read-only portfolio intelligence
 
-### Security & Technology
+> "Summarize my portfolio across Bitcoin, Ethereum, Solana, and Cosmos."
 
-* [Overview](security-and-technology/overview.md): Security architecture
-* [Keysign](security-and-technology/keysign.md): Transaction signing
-* [TSS Actions](security-and-technology/tss-actions.md): Threshold signature operations
-* [How GG20 Works](security-and-technology/how-gg20-works.md): GG20 protocol
-* [How DKLS23 Works](security-and-technology/how-dkls23-works.md): DKLS23 protocol
-* [Difference to Multi-Signatures](security-and-technology/difference-to-multi-sig.md): TSS vs multisig
-* [Emergency Recovery](security-and-technology/emergency-recovery.md): Recovery procedures
+The agent queries addresses, native and token balances, and fiat values without signing a transaction.
 
-### Ecosystem
+### Preview, then execute
 
-* [Vultisig Extension](vultisig-ecosystem/vultisig-extension/): Browser extension for dApps
-* [Plugin Marketplace](vultisig-ecosystem/marketplace.md): Self-custodial automation — plugins and AI agents
-* [Web App](vultisig-ecosystem/web-app.md): Browser-based vault access
-* [Vultisig SDK](vultisig-ecosystem/vultisig-sdk.md): SDK overview with agent section
-* [Community Tools](vultisig-ecosystem/community-tools.md): Third-party tools
+> "Prepare a 0.1 ETH transfer, show me the fee and total, then wait for approval."
 
-### VULT Token
+The agent uses a dry run to surface the expected cost and transaction details before entering the selected signing flow.
 
-* [The $VULT Token](vultisig-token/vult/): Tokenomics and utility
-* [In-App Utility](vultisig-token/vult/in-app-utility.md): Fee discounts, staking tiers
-* [Marketplace Utility](vultisig-token/vult/marketplace-utility.md): Revenue distribution
-* [Governance](vultisig-token/vult/governance-utility.md): Voting rights
+### Natural-language cross-chain swaps
 
-### Infrastructure
+> "Swap 0.1 ETH to BTC using the best available route."
 
-* [Overview](vultisig-infrastructure/overview.md): Architecture
-* [Vultiserver](vultisig-infrastructure/what-is-vultisigner/): Co-signing server for Fast Vaults
-* [Transaction Policies](vultisig-infrastructure/what-is-vultisigner/what-can-be-configured.md): Spending limits, whitelists, time delays
-* [Relay Server](vultisig-infrastructure/relay-server.md): Device session coordination
+The agent can request a quote, explain estimated output and fees, then execute through THORChain, 1inch, KyberSwap, LiFi, or another supported route.
 
-### Developer Docs
+### Policy-bound automation
 
-* [Developer Home](developer-docs/): Entry point
-* [Marketplace Plugins](developer-docs/marketplace/): Build and publish plugins
-  * [What is a Plugin](developer-docs/marketplace/infrastructure-overview/plugins.md): Architecture and scope
-  * [Services Architecture](developer-docs/marketplace/infrastructure-overview/services.md): Service components
-  * [Policy Rules](developer-docs/marketplace/infrastructure-overview/metarules.md): Transaction validation rules
-  * [Infrastructure](developer-docs/marketplace/infrastructure-overview/infrastructure.md): Plugin infrastructure
-  * [Quick Start](developer-docs/marketplace/create-a-plugin/basics-quick-start.md): Scaffold your first plugin
-  * [Build Your Plugin](developer-docs/marketplace/create-a-plugin/build-your-plugin/): Full development guide
-  * [Submission & Revenue](developer-docs/marketplace/create-a-plugin/submission-process.md): Review process, 70/30 split
-* [Extension Integration](developer-docs/vultisig-extension-integration-guide.md): window.vultisig API, code examples
-* [SDK](developer-docs/vultisig-sdk/): Full SDK docs
-  * [SDK Implementation Guide](developer-docs/vultisig-sdk/SDK-USERS-GUIDE.md): Detailed usage guide
-  * [SDK CLI](developer-docs/vultisig-sdk/CLI.md): CLI reference
+> "Rebalance when BTC moves outside 45-55% of the portfolio, but never trade more than $500 per day."
 
-### Help & Legal
+A Marketplace agent can monitor conditions and propose transactions while the Verifier enforces the rules configured by the user.
 
-* [FAQ](help/faq.md): Common questions
-* [Security](help/security.md): Security policy
-* [Privacy](help/privacy.md): Privacy policy
-* [Terms of Use](help/terms.md): Terms
+## The security boundary
+
+Vultisig removes the complete private key as a single point of failure, but MPC does not make an agent's decisions correct. Your application is still responsible for prompts, strategy logic, token and contract selection, transaction parameters, credential storage, and economic outcomes.
+
+Before allowing an agent to sign:
+
+* Use dry runs and surface the destination, assets, fees, and expected output.
+* Prefer a Secure Vault when every transaction needs human approval.
+* Prefer Marketplace policies when autonomy should be limited by explicit rules.
+* Protect vault passwords and backups; do not embed them in prompts, source code, or logs.
+* Treat arbitrary message and byte signing as high-risk capabilities.
+
+{% hint style="warning" %}
+Fast Vaults enable unattended signing. Only fund an autonomous vault with an amount appropriate for the workflow's risk, and keep a tested vault backup.
+{% endhint %}
+
+## Agent discovery
+
+Vultisig publishes machine-readable resources for agents and coding assistants:
+
+| Resource | Purpose |
+| --- | --- |
+| [SKILL.md](https://vultisig.com/SKILL.md) | Operating instructions for balances, sends, swaps, gas estimation, and vault workflows |
+| [llms.txt](https://vultisig.com/llms.txt) | Compact documentation index |
+| [llms-full.txt](https://vultisig.com/llms-full.txt) | Full SDK context and examples |
+| [agent.json](https://vultisig.com/.well-known/agent.json) | Structured capabilities manifest |
+| [MCP server](https://github.com/vultisig/mcp) | Experimental MCP tools for EVM reads and transaction building |
+
+{% hint style="info" %}
+The MCP server is a work in progress. For production wallet operations, use the SDK, CLI, or Marketplace plugin infrastructure.
+{% endhint %}
+
+## Get started
+
+* **Give an existing coding agent a wallet:** install the [CLI](developer-docs/vultisig-sdk/CLI.md).
+* **Build a long-running agent or bot:** integrate the [TypeScript SDK](developer-docs/vultisig-sdk/).
+* **Build constrained autonomous strategies:** start with the [Marketplace developer docs](developer-docs/marketplace/).
+* **Require a person to approve every signature:** use a [Secure Vault](app-guide/creating-a-vault/secure-vault.md).

--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -16,6 +16,17 @@ These are just examples. Vultisig's MPC infrastructure is chain-agnostic and pro
 
 ## Choose Your Path
 
+### AI Agents
+
+Give agents multi-chain wallet capabilities and choose between autonomous, policy-bound, and human-approved signing.
+
+* **Languages**: TypeScript, shell, or Go
+* **Best for**: Coding agents, trading bots, payment automation, and portfolio strategies
+
+{% content-ref url="ai-agents/" %}
+[ai-agents](ai-agents/)
+{% endcontent-ref %}
+
 ### Marketplace Plugins
 
 Build automation plugins that run on Vultisig's infrastructure and are distributed through the Marketplace.

--- a/developer-docs/ai-agents/README.md
+++ b/developer-docs/ai-agents/README.md
@@ -50,8 +50,8 @@ Marketplace agents can monitor conditions and propose transactions while a Verif
 
 ## Start building
 
-* **Give an existing coding agent a wallet:** use the [CLI](../vultisig-sdk/CLI.md).
-* **Build a TypeScript agent or service:** integrate the [SDK](../vultisig-sdk/).
+* **Give any agent a wallet (start here):** the [CLI](../vultisig-sdk/CLI.md) is the fastest path — structured JSON, stable exit codes, and a natural-language `agent ask` mode built for AI-to-AI use. It runs unattended in non-interactive environments with no extra setup.
+* **Embed wallet logic into your own service:** integrate the [TypeScript SDK](../vultisig-sdk/).
 * **Publish constrained autonomous strategies:** build a [Marketplace plugin](../marketplace/).
 * **Choose the right approval model:** read [Authority and security](authority-and-security.md).
 * **Compare the available developer surfaces:** read [Integration options](integration-options.md).

--- a/developer-docs/ai-agents/README.md
+++ b/developer-docs/ai-agents/README.md
@@ -1,0 +1,58 @@
+---
+description: >-
+  Build AI agents with multi-chain wallet capabilities and choose exactly how
+  much signing authority they receive.
+---
+
+# AI Agents
+
+Vultisig gives AI agents a programmable, seedless wallet across 40+ blockchains. Agents can inspect portfolios, prepare transactions, send assets, swap across chains, and sign messages without ever holding a complete private key.
+
+The defining choice is not whether an agent can transact. It is **how much authority the agent should have**.
+
+## Why Vultisig for agents?
+
+Most agent wallets force developers to choose between two extremes: a fully autonomous hot wallet or manual approval for every action. Vultisig supports multiple signing models through the same multi-chain MPC infrastructure.
+
+| Operating model | Best for | Signing authority |
+| --- | --- | --- |
+| **Autonomous Fast Vault** | Bots and services that must transact without a person present | The agent's device and VultiServer form a 2-of-2 MPC vault |
+| **Policy-bound automation** | Autonomous strategies with explicit user limits | A Marketplace plugin proposes; an independent Verifier enforces the configured rules |
+| **Human-approved Secure Vault** | Higher-value workflows requiring approval | The configured threshold of human-controlled devices joins every signing session |
+
+Use the least authority that still lets the workflow succeed. See [Authority and security](authority-and-security.md) for the full decision guide.
+
+## What agents can do
+
+### Portfolio intelligence
+
+> "Summarize my holdings across Bitcoin, Ethereum, Solana, and Cosmos."
+
+Query addresses, native and token balances, and fiat values without signing a transaction.
+
+### Preview and execute transactions
+
+> "Prepare a 0.1 ETH transfer, show me the fee and total, then wait for approval."
+
+Prepare and inspect transaction details before entering the selected signing flow.
+
+### Cross-chain swaps
+
+> "Swap 0.1 ETH to BTC using the best available route."
+
+Request quotes and execute swaps through supported providers such as THORChain, 1inch, KyberSwap, and LiFi.
+
+### Policy-bound strategies
+
+> "Rebalance when BTC moves outside 45-55% of the portfolio, but never trade more than $500 per day."
+
+Marketplace agents can monitor conditions and propose transactions while a Verifier enforces the user's rules.
+
+## Start building
+
+* **Give an existing coding agent a wallet:** use the [CLI](../vultisig-sdk/CLI.md).
+* **Build a TypeScript agent or service:** integrate the [SDK](../vultisig-sdk/).
+* **Publish constrained autonomous strategies:** build a [Marketplace plugin](../marketplace/).
+* **Choose the right approval model:** read [Authority and security](authority-and-security.md).
+* **Compare the available developer surfaces:** read [Integration options](integration-options.md).
+

--- a/developer-docs/ai-agents/README.md
+++ b/developer-docs/ai-agents/README.md
@@ -17,7 +17,7 @@ Vultisig supports multiple signing models through the same multi-chain MPC infra
 | Operating model | Best for | Signing authority |
 | --- | --- | --- |
 | **Autonomous Fast Vault** | Bots and services that must transact without a person present | The agent and VultiServer each hold one share of a 2-of-2 MPC vault |
-| **Policy-bound automation** | Autonomous strategies with explicit user limits | A Marketplace plugin proposes; the Vultisig-managed Verifier enforces the configured rules |
+| **Policy-bound automation** | Autonomous strategies with explicit user limits | A Marketplace plugin proposes; the Verifier enforces the configured rules |
 | **Human-approved Secure Vault** | Higher-value workflows requiring approval | The configured threshold of human-controlled devices joins every signing session |
 
 Use the least authority that still lets the workflow succeed. See [Authority and security](authority-and-security.md) for the full decision guide.

--- a/developer-docs/ai-agents/README.md
+++ b/developer-docs/ai-agents/README.md
@@ -12,12 +12,12 @@ The defining choice is not whether an agent can transact. It is **how much autho
 
 ## Why Vultisig for agents?
 
-Most agent wallets force developers to choose between two extremes: a fully autonomous hot wallet or manual approval for every action. Vultisig supports multiple signing models through the same multi-chain MPC infrastructure.
+Vultisig supports multiple signing models through the same multi-chain MPC infrastructure, so developers can match an agent's authority to the workflow.
 
 | Operating model | Best for | Signing authority |
 | --- | --- | --- |
-| **Autonomous Fast Vault** | Bots and services that must transact without a person present | The agent's device and VultiServer form a 2-of-2 MPC vault |
-| **Policy-bound automation** | Autonomous strategies with explicit user limits | A Marketplace plugin proposes; an independent Verifier enforces the configured rules |
+| **Autonomous Fast Vault** | Bots and services that must transact without a person present | The agent and VultiServer each hold one share of a 2-of-2 MPC vault |
+| **Policy-bound automation** | Autonomous strategies with explicit user limits | A Marketplace plugin proposes; the Vultisig-managed Verifier enforces the configured rules |
 | **Human-approved Secure Vault** | Higher-value workflows requiring approval | The configured threshold of human-controlled devices joins every signing session |
 
 Use the least authority that still lets the workflow succeed. See [Authority and security](authority-and-security.md) for the full decision guide.

--- a/developer-docs/ai-agents/README.md
+++ b/developer-docs/ai-agents/README.md
@@ -55,4 +55,3 @@ Marketplace agents can monitor conditions and propose transactions while a Verif
 * **Publish constrained autonomous strategies:** build a [Marketplace plugin](../marketplace/).
 * **Choose the right approval model:** read [Authority and security](authority-and-security.md).
 * **Compare the available developer surfaces:** read [Integration options](integration-options.md).
-

--- a/developer-docs/ai-agents/authority-and-security.md
+++ b/developer-docs/ai-agents/authority-and-security.md
@@ -59,4 +59,3 @@ Your application remains responsible for:
 {% hint style="warning" %}
 Fast Vaults enable unattended signing. Only grant an agent the assets and capabilities its workflow requires.
 {% endhint %}
-

--- a/developer-docs/ai-agents/authority-and-security.md
+++ b/developer-docs/ai-agents/authority-and-security.md
@@ -1,0 +1,62 @@
+---
+description: >-
+  Choose between autonomous, policy-bound, and human-approved agent signing
+  models with Vultisig.
+---
+
+# Authority and security
+
+MPC removes the complete private key as a single point of failure. It does not make an agent's decisions correct. Choose a signing model based on the value at risk, the workflow's speed requirements, and the controls that must remain outside the agent.
+
+## Compare signing models
+
+### Autonomous Fast Vault
+
+A Fast Vault combines the agent-controlled device share with a VultiServer share. The agent can sign without a person present.
+
+**Use when:** the workflow requires unattended execution and the vault can be funded according to a defined risk budget.
+
+**Primary controls:** isolated vaults, limited funding, protected credentials, transaction previews, monitoring, and tested backups.
+
+### Policy-bound Marketplace automation
+
+A Marketplace plugin proposes unsigned transactions. A separate Verifier checks each proposal against the user's configured policy before participating in MPC signing.
+
+**Use when:** an autonomous strategy should operate inside explicit limits, such as allowed assets, destinations, amounts, or timing.
+
+**Primary controls:** narrowly scoped rules, independent validation, plugin review, monitoring, and the ability to disable the automation.
+
+### Human-approved Secure Vault
+
+A Secure Vault requires the configured threshold of devices to join each signing session. The agent can research and prepare an action, but cannot complete the signature alone.
+
+**Use when:** every transaction requires human review or multiple participants must approve.
+
+**Primary controls:** transaction review, device separation, threshold configuration, backups, and clear approval procedures.
+
+## Responsibilities that remain with the developer
+
+Your application remains responsible for:
+
+* Prompt and tool-call security
+* Strategy logic and economic outcomes
+* Token, contract, route, and destination selection
+* Transaction parameters and fee limits
+* Vault passwords, backups, logs, and runtime credentials
+* Monitoring, incident response, and disabling compromised agents
+
+## Recommended controls
+
+* Start with read-only portfolio access.
+* Require previews before enabling signing.
+* Use separate vaults for separate agents or strategies.
+* Fund autonomous vaults only to an explicit risk budget.
+* Prefer policy-bound automation when rules can constrain the workflow.
+* Prefer Secure Vaults for high-value or irreversible actions.
+* Treat arbitrary message and byte signing as high-risk capabilities.
+* Never embed vault passwords or backups in prompts, source code, or logs.
+
+{% hint style="warning" %}
+Fast Vaults enable unattended signing. Only grant an agent the assets and capabilities its workflow requires.
+{% endhint %}
+

--- a/developer-docs/ai-agents/authority-and-security.md
+++ b/developer-docs/ai-agents/authority-and-security.md
@@ -12,7 +12,7 @@ MPC removes the complete private key as a single point of failure. It does not m
 
 ### Autonomous Fast Vault
 
-A Fast Vault combines the agent-controlled device share with a VultiServer share. The agent can sign without a person present.
+A Fast Vault combines an agent-controlled share with a VultiServer share. The agent can sign without a person present.
 
 **Use when:** the workflow requires unattended execution and the vault can be funded according to a defined risk budget.
 
@@ -20,15 +20,15 @@ A Fast Vault combines the agent-controlled device share with a VultiServer share
 
 ### Policy-bound Marketplace automation
 
-A Marketplace plugin proposes unsigned transactions. A separate Verifier checks each proposal against the user's configured policy before participating in MPC signing.
+A Marketplace plugin proposes unsigned transactions. The Vultisig-managed Verifier checks each proposal against the user's configured policy before participating in MPC signing.
 
 **Use when:** an autonomous strategy should operate inside explicit limits, such as allowed assets, destinations, amounts, or timing.
 
-**Primary controls:** narrowly scoped rules, independent validation, plugin review, monitoring, and the ability to disable the automation.
+**Primary controls:** narrowly scoped rules, Verifier policy validation, plugin review, monitoring, and the ability to disable the automation.
 
 ### Human-approved Secure Vault
 
-A Secure Vault requires the configured threshold of devices to join each signing session. The agent can research and prepare an action, but cannot complete the signature alone.
+A Secure Vault requires the configured threshold of devices to join each signing session. In a human-approved setup, the agent prepares the action and the human-controlled shares complete the signing threshold.
 
 **Use when:** every transaction requires human review or multiple participants must approve.
 

--- a/developer-docs/ai-agents/authority-and-security.md
+++ b/developer-docs/ai-agents/authority-and-security.md
@@ -20,7 +20,7 @@ A Fast Vault combines an agent-controlled share with a VultiServer share. The ag
 
 ### Policy-bound Marketplace automation
 
-A Marketplace plugin proposes unsigned transactions. The Vultisig-managed Verifier checks each proposal against the user's configured policy before participating in MPC signing.
+A Marketplace plugin proposes unsigned transactions. The Verifier checks each proposal against the user's configured policy before participating in MPC signing.
 
 **Use when:** an autonomous strategy should operate inside explicit limits, such as allowed assets, destinations, amounts, or timing.
 

--- a/developer-docs/ai-agents/integration-options.md
+++ b/developer-docs/ai-agents/integration-options.md
@@ -1,7 +1,7 @@
 ---
 description: >-
-  Choose between the Vultisig CLI, TypeScript SDK, Marketplace plugins, and
-  experimental MCP tooling for AI agent integrations.
+  Choose between the Vultisig CLI, TypeScript SDK, Marketplace plugins, and MCP
+  tooling for AI agent integrations.
 ---
 
 # Integration options
@@ -46,7 +46,7 @@ Start with the [SDK guide](../vultisig-sdk/) and [implementation guide](../vulti
 
 ## Marketplace plugins
 
-Use a Marketplace plugin when an agent should act within user-defined rules instead of receiving broad wallet authority. The plugin proposes an unsigned transaction; an independent Verifier checks the proposal before participating in signing.
+Use a Marketplace plugin when an agent should act within user-defined rules instead of receiving broad wallet authority. The plugin proposes an unsigned transaction; the Vultisig-managed Verifier checks the proposal before participating in signing.
 
 Start with the [Marketplace developer docs](../marketplace/).
 
@@ -58,8 +58,4 @@ Start with the [Marketplace developer docs](../marketplace/).
 | [llms.txt](https://vultisig.com/llms.txt) | Compact documentation index |
 | [llms-full.txt](https://vultisig.com/llms-full.txt) | Full SDK context and examples |
 | [agent.json](https://vultisig.com/.well-known/agent.json) | Structured capabilities manifest |
-| [MCP server](https://github.com/vultisig/mcp) | Experimental MCP tools for EVM reads and transaction building |
-
-{% hint style="info" %}
-The MCP server is a work in progress. For production wallet operations, use the SDK, CLI, or Marketplace plugin infrastructure.
-{% endhint %}
+| [MCP server](https://github.com/vultisig/mcp) | MCP tools for multi-chain queries, unsigned transaction building, DeFi interactions, and plugin management |

--- a/developer-docs/ai-agents/integration-options.md
+++ b/developer-docs/ai-agents/integration-options.md
@@ -63,4 +63,3 @@ Start with the [Marketplace developer docs](../marketplace/).
 {% hint style="info" %}
 The MCP server is a work in progress. For production wallet operations, use the SDK, CLI, or Marketplace plugin infrastructure.
 {% endhint %}
-

--- a/developer-docs/ai-agents/integration-options.md
+++ b/developer-docs/ai-agents/integration-options.md
@@ -1,0 +1,66 @@
+---
+description: >-
+  Choose between the Vultisig CLI, TypeScript SDK, Marketplace plugins, and
+  experimental MCP tooling for AI agent integrations.
+---
+
+# Integration options
+
+## CLI
+
+Use the Vultisig CLI when an agent can run shell commands. It exposes structured JSON output, non-interactive options, quote commands, and specific exit codes for reliable automation.
+
+```bash
+npm install -g @vultisig/cli
+
+vultisig portfolio --output json
+vultisig swap-quote ethereum bitcoin 0.1 --output json
+vultisig swap ethereum bitcoin 0.1 --output json
+```
+
+See the [CLI reference](../vultisig-sdk/CLI.md).
+
+## TypeScript SDK
+
+Use `@vultisig/sdk` when building wallet capabilities directly into an agent, bot, or application. The SDK handles vault creation, balances, portfolio tracking, sends, swaps, message signing, and transaction broadcasting.
+
+```typescript
+import { Chain, Vultisig } from '@vultisig/sdk'
+
+const sdk = new Vultisig()
+await sdk.initialize()
+
+const vault = await sdk.getActiveVault()
+if (!vault) throw new Error('No active vault')
+
+const portfolio = await vault.portfolio('usd')
+const preview = await vault.send({
+  chain: Chain.Ethereum,
+  to: '0xRecipient',
+  amount: '0.1',
+  dryRun: true,
+})
+```
+
+Start with the [SDK guide](../vultisig-sdk/) and [implementation guide](../vultisig-sdk/SDK-USERS-GUIDE.md).
+
+## Marketplace plugins
+
+Use a Marketplace plugin when an agent should act within user-defined rules instead of receiving broad wallet authority. The plugin proposes an unsigned transaction; an independent Verifier checks the proposal before participating in signing.
+
+Start with the [Marketplace developer docs](../marketplace/).
+
+## Agent discovery resources
+
+| Resource | Purpose |
+| --- | --- |
+| [SKILL.md](https://vultisig.com/SKILL.md) | Operating instructions for balances, sends, swaps, gas estimation, and vault workflows |
+| [llms.txt](https://vultisig.com/llms.txt) | Compact documentation index |
+| [llms-full.txt](https://vultisig.com/llms-full.txt) | Full SDK context and examples |
+| [agent.json](https://vultisig.com/.well-known/agent.json) | Structured capabilities manifest |
+| [MCP server](https://github.com/vultisig/mcp) | Experimental MCP tools for EVM reads and transaction building |
+
+{% hint style="info" %}
+The MCP server is a work in progress. For production wallet operations, use the SDK, CLI, or Marketplace plugin infrastructure.
+{% endhint %}
+

--- a/developer-docs/ai-agents/integration-options.md
+++ b/developer-docs/ai-agents/integration-options.md
@@ -6,23 +6,29 @@ description: >-
 
 # Integration options
 
-## CLI
+## CLI (start here)
 
-Use the Vultisig CLI when an agent can run shell commands. It exposes structured JSON output, non-interactive options, quote commands, and specific exit codes for reliable automation.
+The CLI is the fastest way to give an AI agent a wallet. Any agent that can run shell commands gets multi-chain balances, sends, swaps, and signing — through structured JSON, stable exit codes, and a natural-language `agent ask` mode built for AI-to-AI use. No SDK build step, no embedding.
 
 ```bash
 npm install -g @vultisig/cli
 
+# Structured wallet commands
 vultisig portfolio --output json
 vultisig swap-quote ethereum bitcoin 0.1 --output json
 vultisig swap ethereum bitcoin 0.1 --output json
+
+# Natural-language, one-shot — designed for AI agent integration
+vultisig agent ask "What is my ETH balance?" --password "$VAULT_PASSWORD" --json
 ```
 
-See the [CLI reference](../vultisig-sdk/CLI.md).
+The CLI auto-detects non-interactive (non-TTY) environments and skips the prompts that would otherwise hang an agent, so the same commands run unattended in scripts and pipelines. Set `VAULT_PASSWORD` to avoid interactive password entry, and branch on the documented exit codes and error codes for reliable orchestration.
+
+See the [CLI reference](../vultisig-sdk/CLI.md), including the AI agent integration guide.
 
 ## TypeScript SDK
 
-Use `@vultisig/sdk` when building wallet capabilities directly into an agent, bot, or application. The SDK handles vault creation, balances, portfolio tracking, sends, swaps, message signing, and transaction broadcasting.
+Use `@vultisig/sdk` when you are embedding wallet capabilities directly into your own agent, bot, or service in TypeScript. The SDK handles vault creation, balances, portfolio tracking, sends, swaps, message signing, and transaction broadcasting.
 
 ```typescript
 import { Chain, Vultisig } from '@vultisig/sdk'

--- a/developer-docs/ai-agents/integration-options.md
+++ b/developer-docs/ai-agents/integration-options.md
@@ -46,7 +46,7 @@ Start with the [SDK guide](../vultisig-sdk/) and [implementation guide](../vulti
 
 ## Marketplace plugins
 
-Use a Marketplace plugin when an agent should act within user-defined rules instead of receiving broad wallet authority. The plugin proposes an unsigned transaction; the Vultisig-managed Verifier checks the proposal before participating in signing.
+Use a Marketplace plugin when an agent should act within user-defined rules instead of receiving broad wallet authority. The plugin proposes an unsigned transaction; the Verifier checks the proposal before participating in signing.
 
 Start with the [Marketplace developer docs](../marketplace/).
 

--- a/developer-docs/vultisig-sdk/CLI.md
+++ b/developer-docs/vultisig-sdk/CLI.md
@@ -209,6 +209,103 @@ vultisig --interactive
 vultisig -i
 ```
 
+## AI Agent Integration
+
+The CLI has first-class support for AI agents — both coding agents (Claude Code, Cursor, Opencode) that drive it through shell commands, and agent-to-agent orchestration through a natural-language interface.
+
+### Non-interactive by default
+
+When the CLI runs in a non-TTY environment (pipes, scripts, agents), it auto-detects this and skips interactive prompts that would hang an agent. Vault creation falls back to two-step mode automatically:
+
+```bash
+# Auto-detects non-TTY, skips the interactive OTP prompt, returns immediately
+vultisig create fast --name "Agent Wallet" --password "$VAULT_PASSWORD" --email agent@example.com -o json
+
+# Verify later, once you have the email code
+vultisig verify <vaultId> --code 123456
+```
+
+Use `--ci` for full automation mode (equivalent to `--output json --non-interactive --quiet`). Provide the password through the `--password` flag or the `VAULT_PASSWORD` environment variable so no command blocks on input.
+
+### Agent ask (one-shot)
+
+Send a single natural-language message and get a structured response. This mode is designed for AI-to-AI communication and routes through the Vultisig agent backend.
+
+```bash
+# Query
+vultisig agent ask "What is my ETH balance?" --password "$VAULT_PASSWORD"
+
+# Execute a transaction
+vultisig agent ask "Send 0.01 ETH to 0x742d..." --password "$VAULT_PASSWORD"
+
+# Continue a conversation
+vultisig agent ask "Now swap it to USDC" --session abc123 --password "$VAULT_PASSWORD"
+
+# Structured JSON for parsing
+vultisig agent ask "Check my portfolio" --password "$VAULT_PASSWORD" --json
+```
+
+JSON output:
+
+```json
+{
+  "session_id": "abc123-def456",
+  "response": "Your ETH balance is 1.5 ETH ($3,750.00 USD).",
+  "tool_calls": [
+    { "action": "get_balances", "success": true, "data": { "balances": [{ "chain": "Ethereum", "symbol": "ETH", "amount": "1.5" }] } }
+  ],
+  "transactions": [
+    { "hash": "0x9f8e7d6c...", "chain": "ethereum", "explorerUrl": "https://etherscan.io/tx/0x9f8e7d6c..." }
+  ]
+}
+```
+
+On failure, stdout is a single JSON object with a human-readable `error` and a stable `code`:
+
+```json
+{ "error": "Agent backend unreachable", "code": "BACKEND_UNREACHABLE" }
+```
+
+**Options:**
+
+* `--session <id>` — continue an existing conversation
+* `--backend-url <url>` — agent backend URL (default: `https://abe.vultisig.com`)
+* `--password <password>` — vault password for signing
+* `--json` — output structured JSON
+* `--verbose` — show tool calls and debug info on stderr
+
+### Agent chat and pipe mode
+
+For an interactive chat TUI, or NDJSON agent-to-agent piping:
+
+```bash
+# Interactive chat interface
+vultisig agent
+
+# NDJSON pipe mode for agent-to-agent control (one JSON object per line on stdin/stdout)
+vultisig agent --via-agent --password "$VAULT_PASSWORD"
+```
+
+### Error codes
+
+Orchestrators should branch on `code`, not on the `error` message (which may change between releases). Codes are stable across `agent ask --json`, `--via-agent`, and the executor:
+
+| Code | Typical meaning |
+|------|-----------------|
+| `BACKEND_UNREACHABLE` | Agent health check failed or backend not responding |
+| `AUTH_FAILED` | Auth/token failure, HTTP 401/403, or wrong vault password |
+| `VAULT_LOCKED` | Encrypted vault needs unlock |
+| `PASSWORD_REQUIRED` | Password not supplied when required |
+| `CONFIRMATION_REQUIRED` | User confirmation needed |
+| `ACTION_NOT_IMPLEMENTED` | Local executor does not implement this action |
+| `INVALID_INPUT` | Bad parameters, unknown chain, malformed input |
+| `NETWORK_ERROR` | RPC/fetch connectivity failure |
+| `TIMEOUT` | Deadline exceeded |
+| `TRANSACTION_FAILED` | Build/broadcast/gas error |
+| `SIGNING_FAILED` | MPC/signing failed |
+| `SESSION_NOT_INITIALIZED` | Internal session state error |
+| `UNKNOWN_ERROR` | Unclassified failure |
+
 ## Commands
 
 ### Vault Management


### PR DESCRIPTION
## What changed

- Preserves the existing top-level `agent.md` machine-oriented documentation index
- Adds a dedicated human-facing **Developer Docs > AI Agents** section
- Adds an AI Agents path from Developer Home
- Introduces separate pages for:
  - agent capabilities and use cases
  - autonomous, policy-bound, and human-approved authority models
  - CLI, SDK, Marketplace, discovery resources, and MCP integration

## Why

Vultisig already had strong agent-oriented reference material, but it did not have a focused developer section explaining the product story and helping builders choose the right authority and integration model.

Keeping `agent.md` intact preserves its current discovery/index role. The new pages provide a clearer, extensible home for agentic developer documentation.

## Validation

- Verified all new local documentation links resolve
- Verified CLI examples and options against the current CLI reference
- Verified the TypeScript example against the current SDK source
- Verified all external agent discovery resources resolve
- Verified MCP capabilities against the current `vultisig/mcp` README
- Confirmed `agent.md` is unchanged relative to `main`
- Ran `git diff --check`
