### PR TITLE
[codex] remove dead airdrop docs links

### DIFF
--- a/app-guide/vault-management/vault-qr.md
+++ b/app-guide/vault-management/vault-qr.md
@@ -43,7 +43,7 @@ The Vault QR is a QR code containing the vault's public information for safe sha
 
 ### Airdrop Registration
 
-The Vault QR can be imported into the [Vultisig Airdrop page](https://airdrop.vultisig.com/) to register for the [$VULT airdrop](../../vultisig-token/airdrop/).
+Note: The [$VULT airdrop](../../vultisig-token/airdrop/) has completed and is no longer active.
 
 ### View-Only Access
 

--- a/vultisig-ecosystem/web-app.md
+++ b/vultisig-ecosystem/web-app.md
@@ -1,23 +1,19 @@
 ---
 description: >-
   Vultisig web app for view-only vault access. Perfect for DAOs and treasuries
-  to share holdings publicly. Track your airdrop position.
+  to share holdings publicly.
 ---
 
 # Web App
 
 The web app is a "view-only" version of all Vultisig Vaults, giving DAOs and Treasuries the perfect tool to share their holdings without fear that any stakeholder will be able to access the assets.
 
-It is also used to display the ongoing [airdrop](../vultisig-token/airdrop/) of $VULT to the community.
-
-The website can be accessed here:
-
-{% embed url="https://airdrop.vultisig.com" %}
+Note: The [$VULT airdrop](../vultisig-token/airdrop/) has completed and is no longer active.
 
 ## How to connect to the Web App
 
 1. Get your [Vault QR](../app-guide/vault-management/vault-qr.md) code from your Vultisig Vault
-2. Open the [web app](https://airdrop.vultisig.com)
+2. Open the web app
 3. Upload your QR code
 4. Access the web app
 

--- a/vultisig-token/airdrop/README.md
+++ b/vultisig-token/airdrop/README.md
@@ -1,20 +1,22 @@
 ---
 description: >-
-  Vultisig $VULT airdrop details. Earn rewards based on vault value and
-  time held. Season structure, eligibility, and how to maximize points.
+  Archived Vultisig $VULT airdrop details, including season structure,
+  eligibility, and point calculations.
 ---
 
 # Airdrop
 
+Note: The $VULT airdrop has completed and is no longer active.
+
 {% hint style="warning" %}
-This is the setup for the current Season 0 and will be discontinued after the current season ends, starting with [Airdrop V2](airdrop-v2.md) to further enhance the airdrop experience. Read more about it [here](https://medium.com/@vultisig/vultisig-airdrop-2-0-how-were-transforming-the-experience-f20c146f2f29) .
+This page documents the completed Season 0 setup. It was discontinued after the season ended, starting with [Airdrop V2](airdrop-v2.md) to further enhance the airdrop experience. Read more about it [here](https://medium.com/@vultisig/vultisig-airdrop-2-0-how-were-transforming-the-experience-f20c146f2f29) .
 {% endhint %}
 
 ***
 
 Early adopters of the Vultisig wallet security standard are highly valued by the project, so Vultisig wants to give back to these high conviction members.
 
-The future $VULT airdrop will be proportionate to:
+The completed $VULT airdrop was proportionate to:
 
 $$
 vault\_asset\_value*time\_in\_vault
@@ -23,7 +25,7 @@ $$
 With the distribution date of 12 months after registration goes live.\
 See further calculation [here](./#airdrop-process).\
 \
-Users will receive full information about how to register for this airdrop in the coming weeks.
+Registration information was provided during the active airdrop period.
 
 ***
 
@@ -74,20 +76,20 @@ The Ongoing Airdrop Process will continue for another 5 years, and the dedicated
 
 ***
 
-## How to register for the airdrop
+## Historical registration process
 
-1.  [Export](../../app-guide/vault-management/vault-qr.md) the Vault QR of the Vultisig Vault\\
+1.  Users [exported](../../app-guide/vault-management/vault-qr.md) the Vault QR of the Vultisig Vault\\
 
     <figure><img src="../../.gitbook/assets/VultisigQR-Main Vault-828.png" alt="" width="188"><figcaption></figcaption></figure>
-2.  Connect to the [airdrop](https://airdrop.vultisig.com/import) page with your [Vultisig Extension](../../vultisig-ecosystem/vultisig-extension/) or by uploading your Vault QR\\
+2.  Users connected with the [Vultisig Extension](../../vultisig-ecosystem/vultisig-extension/) or by uploading their Vault QR\\
 
     <figure><img src="../../.gitbook/assets/image (11).png" alt="" width="375"><figcaption></figcaption></figure>
-3.  Join the Airdrop with your connected Vault with clicking `Join Airdrop` on the website\\
+3.  Users joined the airdrop with their connected vault by clicking `Join Airdrop` on the website\\
 
     <figure><img src="../../.gitbook/assets/image (14).png" alt="" width="188"><figcaption></figcaption></figure>
-4. Go to the `Balance` tab and enable **ALL a**ssets you want to have counted towards the airdrop
-5. Earn VULTIES (Airdrop points) and track the leaderboard
-6. Register multiple Vaults
+4. Users went to the `Balance` tab and enabled **ALL a**ssets they wanted to have counted towards the airdrop
+5. Users earned VULTIES (Airdrop points) and tracked the leaderboard
+6. Users registered multiple Vaults
 
 {% hint style="warning" %}
 You need to enable all Chains and Tokens you want to have counted towards the airdrop once!
@@ -101,7 +103,7 @@ In order to make the Vultisig Airdrop more game-like and to further increase the
 
 The multiplier will accumulate, similar to the VULTIES (airdrop points) and will be calculated at the end of the airdrop phase to get the complete airdrop share.
 
-This gives the opportunity to increase the personal multiplier over the course of the ongoing 12 month Airdrop without affecting the VULTIES.
+This gave users the opportunity to increase their personal multiplier over the course of the 12 month airdrop without affecting the VULTIES.
 
 The multiplier will start at 1 and will increase depending on the activities and programms, set by the Vultisig team.
 

--- a/vultisig-token/airdrop/airdrop-v2.md
+++ b/vultisig-token/airdrop/airdrop-v2.md
@@ -1,16 +1,18 @@
 ---
 description: >-
-  Vultisig Airdrop V2: Enhanced rewards system. Earn $VULT based on vault
-  value × time held. Achievement tiers, daily drops, and multipliers.
+  Archived Vultisig Airdrop V2 details, including eligibility, point
+  calculations, and multipliers.
 cover: ../../.gitbook/assets/Vultisig - 1200x630 - 56- 2x.png
 coverY: 0
 ---
 
 # Airdrop V2
 
+Note: The $VULT airdrop has completed and is no longer active.
+
 Early adopters of the Vultisig wallet security standard are highly valued by the project, so Vultisig wants to give back to these high conviction members.&#x20;
 
-The future $VULT airdrop will be proportional:
+The completed $VULT airdrop was proportional:
 
 $$
 vault\_asset\_value*time\_in\_vault
@@ -95,7 +97,7 @@ This multiplier logarithmically multiplies and caps at 500 referrals, providing 
 
 ### Dedicated tokens and community multipliers
 
-To attract more attention and expand the Vultisquad community, a special multiplier will be introduced for holding selected tokens or NFTs that will be selected in the coming future.&#x20;
+To attract more attention and expand the Vultisquad community, a special multiplier was planned for holding selected tokens or NFTs.&#x20;
 
 The first token to receive this treatment will be $VULT itself, which will grant holders a 1.5x multiplier on its dollar value within the airdrop calculation.
 
@@ -150,27 +152,27 @@ $$
 
 ***
 
-## How to register for the airdrop
+## Historical registration process
 
-* Download and open your Vultisig app
+* Users downloaded and opened their Vultisig app
 
 <figure><img src="../../.gitbook/assets/Frame 1000005130.png" alt="" width="279"><figcaption></figcaption></figure>
 
-* [Export](../../app-guide/vault-management/vault-qr.md) the Vault QR of the Vultisig Vault
+* Users [exported](../../app-guide/vault-management/vault-qr.md) the Vault QR of the Vultisig Vault
 
 <figure><img src="../../.gitbook/assets/Frame 1000005131.png" alt="" width="279"><figcaption></figcaption></figure>
 
-*   Connect to the [airdrop](https://airdrop.vultisig.com/import) page with your [Vultisig Extension](https://chromewebstore.google.com/detail/ggafhcdaplkhmmnlbfjpnnkepdfjaelb?utm_source=item-share-cp) or with uploading your Vault QR\
+*   Users connected with the [Vultisig Extension](https://chromewebstore.google.com/detail/ggafhcdaplkhmmnlbfjpnnkepdfjaelb?utm_source=item-share-cp) or by uploading their Vault QR\
 
 
     <figure><img src="../../.gitbook/assets/image (11).png" alt="" width="375"><figcaption></figcaption></figure>
-*   Join the Airdrop with your connected Vault with clicking `Join Airdrop` on the [web app](../../vultisig-ecosystem/web-app.md)\
+*   Users joined the airdrop with their connected vault by clicking `Join Airdrop` on the [web app](../../vultisig-ecosystem/web-app.md)\
 
 
     <figure><img src="../../.gitbook/assets/Button.png" alt="" width="225"><figcaption></figcaption></figure>
-* Go to the `Balances` tab and check for auto-discovery or enable **ALL a**ssets you want to have counted towards the airdrop
-* Earn VULTIES (Airdrop points) and track the leaderboard
-* Register multiple Vaults
+* Users went to the `Balances` tab and checked for auto-discovery or enabled **ALL a**ssets they wanted to have counted towards the airdrop
+* Users earned VULTIES (Airdrop points) and tracked the leaderboard
+* Users registered multiple Vaults
 
 {% hint style="warning" %}
 You need to enable all Chains and Tokens you want to have counted towards the airdrop once!


### PR DESCRIPTION
## What changed

- remove dead `airdrop.vultisig.com` links from four docs pages:
  - `app-guide/vault-management/vault-qr.md`
  - `vultisig-ecosystem/web-app.md`
  - `vultisig-token/airdrop/README.md`
  - `vultisig-token/airdrop/airdrop-v2.md`
- add plain notes that the `$VULT` airdrop has completed and is no longer active
- convert the registration sections to historical wording

## Why

`airdrop.vultisig.com` currently does not resolve, and the airdrop is completed, so the docs should not send readers to a dead registration endpoint or present registration as active.

## Validation

- verified `https://airdrop.vultisig.com` and `/import` fail with `ENOTFOUND`
- confirmed no `airdrop.vultisig.com` references remain in the docs repo
- confirmed the affected pages no longer use active/future phrasing for registration
- `git diff --check`
